### PR TITLE
Set the site for taxonomy term

### DIFF
--- a/src/Taxonomies/Term.php
+++ b/src/Taxonomies/Term.php
@@ -4,6 +4,7 @@ namespace Daynnnnn\StatamicDatabase\Taxonomies;
 
 use Illuminate\Support\Arr;
 use Illuminate\Support\Collection;
+use Statamic\Facades\Site;
 use Statamic\Facades\Term as TermFacade;
 use Statamic\Taxonomies\Term as FileTerm;
 
@@ -23,7 +24,7 @@ class Term extends FileTerm
         foreach (Arr::pull($data, 'localizations', []) as $locale => $localeData) {
             $term->dataForLocale($locale, $localeData);
         }
-        
+
         $term->dataForLocale($term->defaultLocale(), $data);
 
         return $term;
@@ -34,9 +35,9 @@ class Term extends FileTerm
         $model = TermModel::firstOrNew([
             'slug' => $this->slug(),
         ]);
-        
+
         $model->taxonomy = $this->taxonomy;
-        $model->data = $this->fileData();
+        $model->data = $this->dbData();
         $model->save();
 
         return $model;
@@ -58,5 +59,14 @@ class Term extends FileTerm
     public function lastModified()
     {
         return $this->model->updated_at;
+    }
+
+    public function dbData()
+    {
+        $data = $this->fileData();
+
+        $data['site'] = Site::current()->handle();
+
+        return $data;
     }
 }


### PR DESCRIPTION
Hi!

To support multi-sites Statamic uses folder structure. In case of DB we should set the site directly in the `data` of taxonomy term otherwise we just can't get the terms:
![image](https://user-images.githubusercontent.com/2729547/122577950-11d9ff00-d05c-11eb-9e7a-5e9815b054b0.png)

![image](https://user-images.githubusercontent.com/2729547/122578309-6b422e00-d05c-11eb-92b9-be6eaa0510ce.png)
