### PR TITLE
Add new config options and improve readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,6 +18,9 @@ An eloquent driver for Statamic V3 which supports:
 From a standard Statamic V3 site, you can run:
 `composer require daynnnnn/statamic-database`
 
+Add the config files:
+`php artisan vendor:publish --tag="statamic-database-config"`
+
 Run migrations:
 `php please migrate`
 
@@ -25,18 +28,44 @@ Then in the register function of your AppServiceProvider, add:
 ```
 public function register()
 {
-    $this->app->singleton(
-        'Statamic\Fields\BlueprintRepository',
-        'Daynnnnn\StatamicDatabase\Blueprints\BlueprintRepository'
-    );
+    if (config('statamic.database.blueprints')) {
+        $this->app->singleton(
+            'Statamic\Fields\BlueprintRepository',
+            'Daynnnnn\StatamicDatabase\Blueprints\BlueprintRepository'
+        );
+    }
 
-    $this->app->singleton(
-        'Statamic\Fields\FieldsetRepository',
-        'Daynnnnn\StatamicDatabase\Fieldsets\FieldsetRepository'
-    );
+    if (config('statamic.database.fieldsets')) {
+        $this->app->singleton(
+            'Statamic\Fields\FieldsetRepository',
+            'Daynnnnn\StatamicDatabase\Fieldsets\FieldsetRepository'
+        );
+    }
 }
 ```
 And that should be it!
+
+## Customising what data is stored in the Database
+If you want to customise what data is stored in the database, you can override the default behaviour by altering the config file.
+
+For example if you wanted to store some structure data as yaml so that can be easily inserted into version control you could do:
+
+```php
+return [
+    'assets' => true,
+    'blueprints' => false, // Default true
+    'collections' => false, // Default true
+    'entries' => true,
+    'fieldsets' => false, // Default true
+    'forms' => false, // Default true
+    'form_submissions' => true,
+    'globals' => true,
+    'navigation' => true,
+    'taxonomies' => true,
+];
+```
+
+This will make sure that blueprints, collections, fieldset and forms are stored in yaml files, but still keep submissions and entries in the database.
 
 ## Issues/Things to work on
 

--- a/config/statamic-database.php
+++ b/config/statamic-database.php
@@ -1,19 +1,14 @@
 <?php
 
 return [
-
     'assets' => true,
-
+    'blueprints' => true,
     'collections' => true,
-
     'entries' => true,
-
+    'fieldsets' => true,
     'forms' => true,
-
+    'form_submissions' => true,
     'globals' => true,
-
     'navigation' => true,
-
     'taxonomies' => true,
-    
 ];

--- a/src/Forms/Form.php
+++ b/src/Forms/Form.php
@@ -94,7 +94,14 @@ class Form extends FileForm implements FormContract, Augmentable
      */
     public function submissions()
     {
+        $databaseSubmissions = config('statamic.database.form_submissions');
+
+        if (!$databaseSubmissions) {
+            return parent::submissions();
+        }
+
         $formId = FormModel::where('handle', $this->handle())->first()->id;
+
         return SubmissionModel::where('form_id', $formId)->get()->map(function ($model) {
             return $this->makeSubmission()
                 ->id($model->handle)

--- a/src/Forms/FormRepository.php
+++ b/src/Forms/FormRepository.php
@@ -50,9 +50,16 @@ class FormRepository extends FileFormRepository implements Contract
 
     public static function bindings(): array
     {
-        return [
+        $config = config('statamic.database');
+
+        $baseBindings = [
             FormContract::class => Form::class,
-            SubmissionContract::class => Submission::class,
         ];
+
+        if($config['form_submissions']) {
+            $baseBindings[SubmissionContract::class] = Submission::class;
+        }
+
+        return $baseBindings;
     }
 }

--- a/src/Forms/FormRepository.php
+++ b/src/Forms/FormRepository.php
@@ -6,6 +6,7 @@ use Statamic\Forms\FormRepository as FileFormRepository;
 use Statamic\Contracts\Forms\Form as FormContract;
 use Statamic\Contracts\Forms\FormRepository as Contract;
 use Statamic\Contracts\Forms\Submission as SubmissionContract;
+use Statamic\Forms\Submission as FileSubmission;
 
 class FormRepository extends FileFormRepository implements Contract
 {
@@ -50,16 +51,11 @@ class FormRepository extends FileFormRepository implements Contract
 
     public static function bindings(): array
     {
-        $config = config('statamic.database');
+        $databaseSubmissions = config('statamic.database.form_submissions');
 
-        $baseBindings = [
+        return [
             FormContract::class => Form::class,
+            SubmissionContract::class => $databaseSubmissions ? Submission::class : FileSubmission::class,
         ];
-
-        if($config['form_submissions']) {
-            $baseBindings[SubmissionContract::class] = Submission::class;
-        }
-
-        return $baseBindings;
     }
 }


### PR DESCRIPTION
Added new config options for blueprints, fieldset and form submissions. Also updated the readme to be clearer on customisation.

I needed the ability to customise what was stored in the database and really keep it to only store cms'able data and user submitted data. 
 